### PR TITLE
Deduplication in frost

### DIFF
--- a/R/dictionary.R
+++ b/R/dictionary.R
@@ -297,9 +297,9 @@ metno.frost.ele <- function() {
   # TODO: wind direction is here so we can get DD06, DD12 and DD18 and perform an average.. how?
   x <- rbind(
     c("601" , "Precipitation"		, "1"	, "mm"		, "sum(precipitation_amount *)"),
-    c("401" , "Sea level pressure"	, "1"	, "hPa"		, "mean(surface_air_pressure *)"),
-    c("402" , "Sea level pressure"	, "1"	, "hPa"		, "min(surface_air_pressure *)"),
-    c("403" , "Sea level pressure"	, "1"	, "hPa"		, "max(surface_air_pressure *)"),
+    c("401" , "Sea level pressure"	, "1"	, "hPa"		, "mean(air_pressure_at_sea_level *)"),
+    c("402" , "Sea level pressure"	, "1"	, "hPa"		, "min(air_pressure_at_sea_level *)"),
+    c("403" , "Sea level pressure"	, "1"	, "hPa"		, "max(air_pressure_at_sea_level *)"),
     c("901" , "Snow depth"		, "1"	, "cm"		, "surface_snow_thickness"),
     c("101" , "Mean temperature"	, "1"	, "degree*C"	, "mean(air_temperature *)"),
     c("111" , "Maximum temperature"	, "1"	, "degree*C"	, "max(air_temperature *)"),

--- a/R/metno.frost.data.R
+++ b/R/metno.frost.data.R
@@ -100,6 +100,7 @@ metno.frost.data <- function(keyfile='~/.FrostAPI.key', url='https://frost.met.n
   elementid <- esd2ele(param)
   frostparaminfo <- ele2param(elementid, src="metno.frost")
   frostcfname <- gsub('*', timeresolutions, frostparaminfo$param, fixed=TRUE)
+  frostcfname <- unique(frostcfname) # deduplication
   if (verbose) print( paste('metno.frost.data: Frost parameters:', frostcfname) )
   
   ## Get all station metadata for desired param and time resolution
@@ -107,6 +108,7 @@ metno.frost.data <- function(keyfile='~/.FrostAPI.key', url='https://frost.met.n
   
   ## Get list of relevant stations / source IDs
   frostsources <- metno.frost.stations(stid, lat, lon, meta)
+  frostsources <- unique(frostsources) # deduplication
   if (verbose) print( paste("metno.frost.data: Frost stations:", paste(frostsources, collapse=",")) )
   
   ## Update or set start and end dates using metadata

--- a/R/metno.frost.meta.R
+++ b/R/metno.frost.meta.R
@@ -125,9 +125,10 @@ metno.frost.meta.default <- function(keyfile='~/.FrostAPI.key', param=c("t2m"),
       withstar <- ele2param(x, src="METNO.FROST")$param
       gsub('*', timeresolutions, withstar, fixed=TRUE)
     }
-    ele <- sapply(param, esd2ele)
-    param1s <- sapply(ele, getparam1)
-    names(param1s) <- ele
+    ele <- sapply(param, esd2ele) # pom -> 401
+    ele <- unique(ele) # deduplication
+    param1s <- sapply(ele, getparam1) # 401 -> mean(air_pressure_at_sea_level P1M)
+    names(param1s) <- ele # set number as name for element
     strparam <- paste0(param1s, collapse=",")
     if (verbose) print(paste('metno.frost.meta.default: params:', strparam))
     


### PR DESCRIPTION
Making frost fetching code robust in cases where:
- An element list is provided that produces duplicate frost elements
- A station list is provided that contains duplicates

Each of these cases will result in an error in the returned CSV format from frost.

By deduping the lists beforehand, this should be avoided.

Also, the element code for sea level pressure is corrected.